### PR TITLE
Addresses a "Lexical or preprocessor" build issue by adding a search pat...

### DIFF
--- a/TouchDB Viewer.xcodeproj/project.pbxproj
+++ b/TouchDB Viewer.xcodeproj/project.pbxproj
@@ -320,6 +320,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/../Syncpoint/build/Syncpoint/Build/Products/Debug\"",
+					"\"$(SRCROOT)/Frameworks\"",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TouchDB Viewer/TouchDB Viewer-Prefix.pch";
@@ -335,6 +336,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"$(SRCROOT)/../Syncpoint/build/Syncpoint/Build/Products/Debug\"",
+					"\"$(SRCROOT)/Frameworks\"",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "TouchDB Viewer/TouchDB Viewer-Prefix.pch";


### PR DESCRIPTION
...h for Syncpoint.framework within the /Frameworks subdirectory in the build settings.
