### PR TITLE
Fix build for beta2 API changes.

### DIFF
--- a/Source/DBDocument.m
+++ b/Source/DBDocument.m
@@ -39,7 +39,7 @@
     }
     
     NSString* serverPath = _path.stringByDeletingLastPathComponent;
-    CBLManagerOptions options = {.readOnly = false, .noReplicator = true};
+    CBLManagerOptions options = {.readOnly = false};
     NSError* error;
     _manager = [[CBLManager alloc] initWithDirectory: serverPath
                                              options: &options

--- a/Source/DBWindowController.m
+++ b/Source/DBWindowController.m
@@ -50,7 +50,7 @@
     _docsOutline.doubleAction = @selector(showDocRevisionTree:);
     
     _queryController.outline = _docsOutline;
-    _queryController.query = [_db queryAllDocuments];
+    _queryController.query = [_db createAllDocumentsQuery];
 
     _docEditor.database = _db;
 

--- a/Source/DocHistory.m
+++ b/Source/DocHistory.m
@@ -115,7 +115,7 @@ NSTreeNode* TreeWithoutDeletedBranches(NSTreeNode* root) {
         return nil;
     CBLRevision* rev = root.representedObject;
     if (root.isLeaf) {
-        if (rev.isDeleted)
+        if (rev.isDeletion)
             return nil;
         return [NSTreeNode treeNodeWithRepresentedObject: rev];
     } else {
@@ -138,7 +138,7 @@ static void dumpTree(NSTreeNode* node, int indent, NSMutableString* output) {
     for (int i = 0; i < indent; ++i)
         [output appendString: @"    "];
     CBLRevision* rev = node.representedObject;
-    [output appendFormat: @"%@%@\n", rev.revisionID, (rev.isDeleted ? @" DEL" : @"")];
+    [output appendFormat: @"%@%@\n", rev.revisionID, (rev.isDeletion ? @" DEL" : @"")];
     for (NSTreeNode* child in node.childNodes)
         dumpTree(child, indent+1, output);
 }

--- a/Source/QueryResultController.m
+++ b/Source/QueryResultController.m
@@ -62,11 +62,11 @@
 
 
 - (BOOL) showDeleted {
-    return _query.includeDeleted;
+    return _query.allDocsMode == kCBLIncludeDeleted ? YES : NO;
 }
 
 - (void) setShowDeleted:(BOOL)showDeleted {
-    _query.includeDeleted = showDeleted;
+    _query.allDocsMode = kCBLIncludeDeleted;
     [_query start];
 }
 
@@ -81,8 +81,8 @@
                          change:(NSDictionary *)change context:(void *)context
 {
     if (object == _query) {
-        if (_query.error) {
-            [_docsOutline.window presentError: _query.error];
+        if (_query.lastError) {
+            [_docsOutline.window presentError: _query.lastError];
         } else {
             NSArray* selection;
             CBLDocument* editedDoc = _docEditor.revision.document;
@@ -212,8 +212,8 @@ static NSString* formatProperty( id property ) {
             kColumnIDs = @[@"id", @"rev", @"seq", @"json"];
         switch ([kColumnIDs indexOfObject: identifier]) {
             case 0: return row.documentID;
-            case 1: return formatRevision(row.documentRevision);
-            case 2: return @(row.localSequence);
+            case 1: return formatRevision(row.documentRevisionID);
+            case 2: return @(row.sequenceNumber);
             case 3: return formatProperty(row.document.userProperties);
             default:return @"???";
         }

--- a/Source/RevTreeController.m
+++ b/Source/RevTreeController.m
@@ -68,7 +68,7 @@ static void emboldenCell(NSTextFieldCell *cell, BOOL embolden);
 - (void) setDocument:(CBLDocument *)document {
     _document = document;
     _fullRoot = document ? GetDocRevisionTree(document) : nil;
-    if (!_showDeleted && _document.currentRevision.isDeleted)
+    if (!_showDeleted && _document.currentRevision.isDeletion)
         self.showDeleted = YES;
     else
         [self updateRoot];
@@ -98,7 +98,7 @@ static void emboldenCell(NSTextFieldCell *cell, BOOL embolden);
     NSUInteger count = selIndexes.count;
     NSMutableArray* sel = [NSMutableArray arrayWithCapacity: count];
     [selIndexes enumerateIndexesUsingBlock: ^(NSUInteger idx, BOOL *stop) {
-        CBLRevision* item = [self revisionForItem: [_docsOutline itemAtRow: idx]];
+        CBLRevision* item = [self savedRevisionForItem: [_docsOutline itemAtRow: idx]];
         [sel addObject: item];
     }];
     return sel;
@@ -108,7 +108,7 @@ static void emboldenCell(NSTextFieldCell *cell, BOOL embolden);
 #pragma mark - REVISION-LIST VIEW:
 
 
-- (CBLRevision*) revisionForItem: (id)item {
+- (CBLSavedRevision*) savedRevisionForItem: (id)item {
     NSAssert(item==nil || [item isKindOfClass: [NSTreeNode class]], @"Invalid outline item: %@", item);
     return [item representedObject];
 }
@@ -129,7 +129,7 @@ static NSString* formatProperty( id property ) {
       objectValueForTableColumn:(NSTableColumn *)tableColumn
                          byItem:(id)item
 {
-    CBLRevision* rev = [self revisionForItem: item];
+    CBLSavedRevision* rev = [self savedRevisionForItem: item];
     NSString* identifier = tableColumn.identifier;
     
     if ([identifier hasPrefix: @"."]) {
@@ -160,10 +160,10 @@ static NSString* formatProperty( id property ) {
                    item:(NSTreeNode*)item
 {
     NSString* identifier = col.identifier;
-    CBLRevision* rev = [self revisionForItem: item];
+    CBLSavedRevision* rev = [self savedRevisionForItem: item];
     if ([identifier isEqualToString: @"rev"]) {
-        enableCell(cell, !rev.isDeleted);
-        emboldenCell(cell, [_leaves containsObject: item] && !rev.isDeleted);
+        enableCell(cell, !rev.isDeletion);
+        emboldenCell(cell, [_leaves containsObject: item] && !rev.isDeletion);
     } else if ([identifier isEqualToString: @"json"]) {
         enableCell(cell, rev.propertiesAvailable);
     }
@@ -198,7 +198,7 @@ static NSString* formatProperty( id property ) {
     NSIndexSet* selRows = [_docsOutline selectedRowIndexes];
     if (selRows.count == 1) {
         id item = [_docsOutline itemAtRow: [selRows firstIndex]]; 
-        sel = item ? [self revisionForItem: item] : nil;
+        sel = item ? [self savedRevisionForItem: item] : nil;
     }
     _docEditor.readOnly = YES;
     _docEditor.revision = sel;


### PR DESCRIPTION
The two things I'm uncertain I assumed the right semantics for is the change needed for allDocsMode instead of includeDeleted in QueryResultController.m and CBLSavedRevision objects always being returned by -revisionForItem: in RevTreeController.m.

The other changes look like simple deprecations or symbol renaming to me.
